### PR TITLE
feat: 메인페이지 UI 구성

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.1",
+    "animejs": "^3.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide": "^0.473.0",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@alloc/quick-lru": "^5.2.0",
     "@eslint/eslintrc": "^3.2.0",
+    "@types/animejs": "^3.1.13",
     "@types/node": "^20.17.15",
     "@types/react": "^19.0.7",
     "@types/react-dom": "^19.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.1
         version: 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      animejs:
+        specifier: ^3.2.2
+        version: 3.2.2
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -45,6 +48,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.2.0
         version: 3.2.0
+      '@types/animejs':
+        specifier: ^3.1.13
+        version: 3.1.13
       '@types/node':
         specifier: ^20.17.15
         version: 20.17.15
@@ -376,6 +382,9 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@types/animejs@3.1.13':
+    resolution: {integrity: sha512-yWg9l1z7CAv/TKpty4/vupEh24jDGUZXv4r26StRkpUPQm04ztJaftgpto8vwdFs8SiTq6XfaPKCSI+wjzNMvQ==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -455,6 +464,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  animejs@3.2.2:
+    resolution: {integrity: sha512-Ao95qWLpDPXXM+WrmwcKbl6uNlC5tjnowlaRYtuVDHHoygjtIPfDUoK9NthrlZsQSKjZXlmji2TrBUAVbiH0LQ==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1984,6 +1996,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@types/animejs@3.1.13': {}
+
   '@types/estree@1.0.6': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2091,6 +2105,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  animejs@3.2.2: {}
 
   ansi-regex@5.0.1: {}
 

--- a/frontend/src/app/economy/page.tsx
+++ b/frontend/src/app/economy/page.tsx
@@ -1,0 +1,3 @@
+export default function Economy() {
+  return <div>경제</div>;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -25,9 +25,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        style={{ fontFamily: 'SF_HambakSnow, sans-serif' }}
+        className="flex min-h-screen justify-center"
       >
-        {children}
+        <div className="w-full ">{children}</div>
       </body>
     </html>
   );

--- a/frontend/src/app/life/page.tsx
+++ b/frontend/src/app/life/page.tsx
@@ -1,0 +1,3 @@
+export default function Life() {
+  return <div>생활</div>;
+}

--- a/frontend/src/app/login/layout.tsx
+++ b/frontend/src/app/login/layout.tsx
@@ -13,9 +13,9 @@ export default function RootLayout({
   return (
     <div
       style={{ fontFamily: 'SF_HambakSnow, sans-serif' }}
-      className="flex min-h-screen items-center justify-center bg-[#f2f2f2]"
+      className="flex min-h-screen items-center justify-center bg-[#f3f3f3]"
     >
-      <div className="w-full">{children}</div>
+      <div className=" w-full ">{children}</div>
     </div>
   );
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,53 +1,26 @@
 'use client';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 // components
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 // styles
-import '@/app/login/styles.css';
+import './styles.css';
+
+// constants
+import { loginImgElement } from '@/constants/login';
 
 export default function Login() {
-  const images = [
-    {
-      img: '/images/economy.png',
-      left: '-50',
-      top: '10',
-      alt: '경제',
-      animationClass: 'custom-bounce-1',
-    },
-    {
-      img: '/images/life.png',
-      left: '-10',
-      bottom: '10',
-      alt: '생활',
-      animationClass: 'custom-bounce-2',
-    },
-    {
-      img: '/images/politics.png',
-      left: '400',
-      bottom: '30',
-      alt: '정치',
-      animationClass: 'custom-bounce-3',
-    },
-    {
-      img: '/images/science.png',
-      left: '350',
-      top: '50',
-      alt: '과학',
-      animationClass: 'custom-bounce-1',
-    },
-    {
-      img: '/images/society.png',
-      left: '250',
-      bottom: '-100',
-      alt: '사회',
-      animationClass: 'custom-bounce-2',
-    },
-  ];
+  const router = useRouter();
+
+  // 로그인
+  function login() {
+    router.push('/');
+  }
+
   return (
     <div className="relative bottom-10 flex flex-row w-full h-[420px] items-center justify-around">
       <div className="imgElement relative">
@@ -58,7 +31,7 @@ export default function Login() {
           width={400}
           height={400}
         />
-        {images.map(
+        {loginImgElement.map(
           ({ img, left, top, bottom, alt, animationClass }, index) => {
             return (
               <Image
@@ -106,6 +79,7 @@ export default function Login() {
           <Button
             className="w-[400px] h-[40px] text-[1rem] rounded-[6px] font-[600] hover:bg-[white] hover:text-black hover:border-[2.5px] hover:border-black font-sans"
             size="lg"
+            onClick={login}
           >
             로그인
           </Button>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,167 @@
+'use client';
 import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+// libraries
+import anime from 'animejs/lib/anime.es.js';
+
+// icons
+import { Search } from 'lucide-react';
+
+// styles
+import '@/app/styles.css';
+
+// constants
+import { Images, tabNames } from '@/constants/home';
 
 export default function Home() {
-  return <div>Home</div>;
+  const [isSubjectVisible, setSubjectVisible] = useState<boolean>(false);
+  const [isTitleVisible, setTitleVisible] = useState<boolean>(false);
+  const [componentChange, setComponentChange] = useState<boolean>(false);
+  const [, setIsAnimating] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      // requestAnimationFrame을 사용하여 DOM 업데이트 후 애니메이션 실행
+      requestAnimationFrame(() => {
+        anime({
+          targets: '.function-based-values-demo .el',
+          translateX: (el: HTMLElement) => el.getAttribute('data-x'),
+          translateY: (el: HTMLElement, i: number) => 50 + -50 * i,
+          scale: (el: HTMLElement, i: number, l: number) => l - 5,
+          duration: 1800,
+          delay: () => anime.random(0, 1000),
+          direction: 'reverse',
+          complete: () => {
+            setSubjectVisible(true); // 세상 사는 눈을 키운다 보이기
+            setTimeout(() => {
+              setTitleVisible(true); // News-eye 나중에 보이기
+            }, 500);
+          },
+        });
+      });
+    }, 0); // 0ms 지연을 주어 렌더링 후 함수를 실행
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  function handleInputComponent() {
+    setComponentChange(!componentChange);
+  }
+
+  const toggleComponentChange = () => {
+    setIsAnimating(true);
+    setTimeout(() => {
+      setComponentChange((prev) => !prev);
+      setIsAnimating(false);
+    }, 500); // hideTabs 애니메이션과 일치
+  };
+
+  useEffect(() => {
+    console.log(componentChange);
+  }, [componentChange]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center">
+      <header className="flex flex-row w-[800px] h-[150px] items-center justify-around">
+        <div className="flex flex-row items-center">
+          <Image
+            src={'/images/news-eye.png'}
+            width={55}
+            height={55}
+            alt="로고"
+          />
+          <span className="font-black text-2xl font-[Open_Sans]">News-eye</span>
+        </div>
+
+        {componentChange === true ? (
+          <div className="flex items-center justify-center w-[400px]">
+            <div className="input flex items-center justify-center w-[400px] h-[40px] bg-[#FAFAFA] rounded-[0.5rem] text-[#818181]">
+              <input className="w-[380px] h-[30px] bg-[rgba(255,255,255,0)] border-b-2" />
+            </div>
+          </div>
+        ) : (
+          <div
+            className={
+              'case1 flex flex-row w-[400px] justify-between font-[Open_Sans]'
+            }
+          >
+            {tabNames.map((name, i) => (
+              <Link href={`${name.href}`} key={i}>
+                <span
+                  className="p-2 rounded-[1rem] hover:bg-[#f3f3f3] focus:bg-[#f3f3f3] focus:text-[#797979] cursor-pointer transition-colors duration-300"
+                  tabIndex={0}
+                >
+                  {name.name}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+
+        <Search
+          size={20}
+          className="cursor-pointer"
+          onClick={handleInputComponent}
+        />
+      </header>
+      <main
+        className=" w-full h-[430px] mb-20 flex flex-col justify-center items-center"
+        // style={{
+        //   boxShadow: '0px 1px 5px 3px #f1f1f1',
+        // }}
+      >
+        {isSubjectVisible && (
+          <div className="subject text-5xl animate-showTag">
+            세상 사는 눈을 키운다
+          </div>
+        )}
+        {isTitleVisible && (
+          <span className="title text-4xl text-[#c1c1c1] animate-showTags">
+            News-eye
+          </span>
+        )}
+
+        <div className="function-based-values-demo">
+          {Images.map((img, i) => {
+            const positionStyle = {
+              left: img.left,
+              right: img.right,
+              top: img.top,
+              bottom: img.bottom,
+            };
+            return (
+              <Image
+                key={i}
+                className="el absolute"
+                src={img.src}
+                data-x={img.dataX}
+                alt={img.alt}
+                width={100}
+                height={100}
+                style={positionStyle}
+              />
+            );
+          })}
+        </div>
+      </main>
+      <footer className="flex flex-col items-center justify-evenly w-full h-[200px] bg-[#000000]">
+        <div className="relative left-[50] flex flex-row items-center">
+          <span className="relative top-3 h-[140px] p-10 font-black text-xl font-[Open_Sans] text-white">
+            News-eye
+          </span>
+          <div className="h-[140px] p-10 border-l-[3px] font-black text-sm font-[Open_Sans] text-white">
+            제작자: 서근재
+            <br /> 연락처: 010-0000-0000
+            <br /> 이메일: example@eaxmple.com
+            <br /> 이 프로젝트는 개인 사이드 프로젝트입니다😁
+          </div>
+        </div>
+        <span className="relative right-8 text-white text-[0.8rem]">
+          Copyright ⓒ 서근재
+        </span>
+      </footer>
+    </div>
+  );
 }

--- a/frontend/src/app/politics/page.tsx
+++ b/frontend/src/app/politics/page.tsx
@@ -1,0 +1,3 @@
+export default function Politics() {
+  return <div>정치</div>;
+}

--- a/frontend/src/app/science/page.tsx
+++ b/frontend/src/app/science/page.tsx
@@ -1,0 +1,3 @@
+export default function Science() {
+  return <div>과학</div>;
+}

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -9,44 +9,10 @@ import { Input } from '@/components/ui/input';
 // style
 import '@/app/signup/styles.css';
 
+// constants
+import { signupImgElement } from '@/constants/signup';
+
 export default function Signup() {
-  const images = [
-    {
-      img: '/images/economy.png',
-      left: '-50',
-      top: '10',
-      alt: '경제',
-      animationClass: 'custom-bounce-1',
-    },
-    {
-      img: '/images/life.png',
-      left: '-10',
-      bottom: '10',
-      alt: '생활',
-      animationClass: 'custom-bounce-2',
-    },
-    {
-      img: '/images/politics.png',
-      left: '400',
-      bottom: '30',
-      alt: '정치',
-      animationClass: 'custom-bounce-3',
-    },
-    {
-      img: '/images/science.png',
-      left: '350',
-      top: '50',
-      alt: '과학',
-      animationClass: 'custom-bounce-1',
-    },
-    {
-      img: '/images/society.png',
-      left: '250',
-      bottom: '-100',
-      alt: '사회',
-      animationClass: 'custom-bounce-2',
-    },
-  ];
   return (
     <div className="relative bottom-10 flex flex-row w-full h-[420px] items-center justify-around">
       <div className="containerAnimation relative top-10 flex flex-col justify-around w-[500px] h-[500px] items-center bg-[#ffffff] rounded-[0.5rem]">
@@ -106,7 +72,7 @@ export default function Signup() {
           width={400}
           height={400}
         />
-        {images.map(
+        {signupImgElement.map(
           ({ img, left, top, bottom, alt, animationClass }, index) => {
             return (
               <Image

--- a/frontend/src/app/society/page.tsx
+++ b/frontend/src/app/society/page.tsx
@@ -1,0 +1,3 @@
+export default function Society() {
+  return <div>사회</div>;
+}

--- a/frontend/src/app/styles.css
+++ b/frontend/src/app/styles.css
@@ -1,0 +1,66 @@
+@keyframes showTag {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0px);
+  }
+}
+
+@keyframes showTags {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0px);
+  }
+}
+
+@keyframes showTabs {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0px);
+  }
+}
+
+@keyframes expand {
+  0% {
+    width: 0;
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  100% {
+    width: 400px;
+    opacity: 1;
+    transform: translateY(0px);
+  }
+}
+
+.subject {
+  opacity: 0;
+  animation: showTag 1s forwards;
+}
+
+.title {
+  opacity: 0;
+  animation: showTags 1s forwards;
+}
+
+.case1 {
+  animation: showTabs 0.5s;
+}
+
+.input {
+  animation: expand 1s;
+}

--- a/frontend/src/constants/home.ts
+++ b/frontend/src/constants/home.ts
@@ -1,0 +1,45 @@
+export const tabNames = [
+  { name: 'IT/과학', href: '/science' },
+  { name: '경제', href: '/economy' },
+  { name: '정치', href: '/politics' },
+  { name: '사회', href: '/society' },
+  { name: '생활/문화', href: '/life' },
+];
+
+export const Images = [
+  {
+    dataX: '400px',
+    src: '/images/economy.png',
+    alt: '경제',
+    left: '18rem',
+    top: '10rem',
+  },
+  {
+    dataX: '100px',
+    src: '/images/life.png',
+    alt: '생활/문화',
+    right: '20rem',
+    top: '9rem',
+  },
+  {
+    dataX: '300px',
+    src: '/images/politics.png',
+    alt: '정치',
+    left: '30rem',
+    bottom: '100px',
+  },
+  {
+    dataX: '150px',
+    src: '/images/science.png',
+    alt: '과학',
+    right: '17rem',
+    bottom: '200px',
+  },
+  {
+    dataX: '400px',
+    src: '/images/society.png',
+    alt: '사회',
+    left: '15rem',
+    bottom: '270px',
+  },
+];

--- a/frontend/src/constants/login.ts
+++ b/frontend/src/constants/login.ts
@@ -1,0 +1,37 @@
+export const loginImgElement = [
+  {
+    img: '/images/economy.png',
+    left: '-50',
+    top: '10',
+    alt: '경제',
+    animationClass: 'custom-bounce-1',
+  },
+  {
+    img: '/images/life.png',
+    left: '-10',
+    bottom: '10',
+    alt: '생활',
+    animationClass: 'custom-bounce-2',
+  },
+  {
+    img: '/images/politics.png',
+    left: '400',
+    bottom: '30',
+    alt: '정치',
+    animationClass: 'custom-bounce-3',
+  },
+  {
+    img: '/images/science.png',
+    left: '350',
+    top: '50',
+    alt: '과학',
+    animationClass: 'custom-bounce-1',
+  },
+  {
+    img: '/images/society.png',
+    left: '250',
+    bottom: '-100',
+    alt: '사회',
+    animationClass: 'custom-bounce-2',
+  },
+];

--- a/frontend/src/constants/signup.ts
+++ b/frontend/src/constants/signup.ts
@@ -1,0 +1,37 @@
+export const signupImgElement = [
+  {
+    img: '/images/economy.png',
+    left: '-50',
+    top: '10',
+    alt: '경제',
+    animationClass: 'custom-bounce-1',
+  },
+  {
+    img: '/images/life.png',
+    left: '-10',
+    bottom: '10',
+    alt: '생활',
+    animationClass: 'custom-bounce-2',
+  },
+  {
+    img: '/images/politics.png',
+    left: '400',
+    bottom: '30',
+    alt: '정치',
+    animationClass: 'custom-bounce-3',
+  },
+  {
+    img: '/images/science.png',
+    left: '350',
+    top: '50',
+    alt: '과학',
+    animationClass: 'custom-bounce-1',
+  },
+  {
+    img: '/images/society.png',
+    left: '250',
+    bottom: '-100',
+    alt: '사회',
+    animationClass: 'custom-bounce-2',
+  },
+];


### PR DESCRIPTION
<!-- 제목: [Feature] PR내용
ex) [Feature] 프로젝트 초기 세팅 -->

## 이슈 번호
#3 
## 구현 내용
- 검색창 <= ⇒  탭 서로 전환 시에 애니메이션 적용
- DOM 업데이트 후 애니메이션 실행
- 각 분야별 페이지 생성

## 관련 기술 설명
useEffect를 사용하여 리렌더링 시에 애니메이션이 클라이언트측에서 실행될 수 있도록 구성함
하지만 첫 렌더링에 애니메이션이 이미지 요소가 렌더링 되기 전에 실행돼서 화면에 출력되지 않는 버그 발생
requestAnimationFrame를 사용하여 요소가 DOM에 렌더링된 후 애니메이션을 시작하도록 구성하여 해결
애니메이션을 브라우저의 리프레시 주기에 맞춰 실행시키고, DOM의 위치가 완전히 업데이트 된 후 호출될 수 있도록 한다.
```typescript
useEffect(() => {
    const timer = setTimeout(() => {
      // requestAnimationFrame을 사용하여 DOM 업데이트 후 애니메이션 실행
      requestAnimationFrame(() => {
        anime({
          targets: '.function-based-values-demo .el',
          translateX: (el: HTMLElement) => el.getAttribute('data-x'),
          translateY: (el: HTMLElement, i: number) => 50 + -50 * i,
          scale: (el: HTMLElement, i: number, l: number) => l - 5,
          duration: 1800,
          delay: () => anime.random(0, 1000),
          direction: 'reverse',
          complete: () => {
            setSubjectVisible(true); 
            setTimeout(() => {
              setTitleVisible(true);
            }, 500);
          },
        });
      });
    }, 0); // 0ms 지연을 주어 렌더링 후 함수를 실행

    return () => clearTimeout(timer);
  }, []);
```