### PR TITLE
feat: 로그인/회원가입, 소셜로그인, 뉴스 api 구현

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,17 +1,11 @@
 ---
 name: issue template
 about: 해당 이슈 생성 템플릿을 사용하여 이슈를 생성해주세요
-title: "[Fix, Feature, Refactor, Chore]"
+title: '[Fix, Feat, Refactor, Chore]'
 labels: ''
 assignees: ''
-
 ---
 
-## 배경
-이게 왜 필요한지에 대한 설명.
-예를 들어서 기능 구현의 경우 어떤 라이브러를 썼을 때 
-무지성 도입이 아니라 왜 이걸 썼는지에 대한 설명
-기능 수정은 왜 수정해야하는지 등등
-
 ## ✅ TODO
+
 - [ ]

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "express": "^4.21.2",
     "morgan": "^1.10.0",
     "mysql2": "^3.12.0",
+    "node-fetch": "^3.3.2",
     "nodemon": "^3.1.9"
   },
   "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       mysql2:
         specifier: ^3.12.0
         version: 3.12.0
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
       nodemon:
         specifier: ^3.1.9
         version: 3.1.9
@@ -344,6 +347,10 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -424,6 +431,10 @@ packages:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -431,6 +442,10 @@ packages:
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -589,6 +604,14 @@ packages:
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   nodemon@3.1.9:
     resolution: {integrity: sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==}
@@ -776,6 +799,10 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
@@ -1029,6 +1056,8 @@ snapshots:
 
   create-require@1.1.1: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -1136,6 +1165,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -1151,6 +1185,10 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -1296,6 +1334,14 @@ snapshots:
       lru-cache: 7.18.3
 
   negotiator@0.6.3: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   nodemon@3.1.9:
     dependencies:
@@ -1488,5 +1534,7 @@ snapshots:
   v8-compile-cache-lib@3.0.1: {}
 
   vary@1.1.2: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   yn@3.1.1: {}

--- a/backend/src/config/db.ts
+++ b/backend/src/config/db.ts
@@ -1,0 +1,16 @@
+import dotenv from 'dotenv';
+import mysql from 'mysql2/promise';
+
+// 환경 변수 로딩
+dotenv.config({});
+
+const dbConfig = {
+  host: process.env.HOST,
+  user: process.env.DB_USER,
+  password: process.env.PASSWORD,
+  database: process.env.DATABASE,
+};
+
+const pool = mysql.createPool(dbConfig);
+
+export { dbConfig, pool };

--- a/backend/src/controllers/newsController.ts
+++ b/backend/src/controllers/newsController.ts
@@ -1,0 +1,89 @@
+import { Request, Response } from 'express';
+import news from '../models/newsModel';
+import { NewsDataType } from '../types/news';
+import { ResultSetHeader } from 'mysql2';
+
+const getAllNews = async (_req: Request, res: Response) => {
+  try {
+    const myNews = await news.getMyNews();
+    console.log(myNews);
+
+    if (myNews) {
+      res.status(200).json(myNews);
+    } else {
+      res.status(404).json({ message: 'News not found' });
+    }
+  } catch (e) {
+    console.error('Error fetching entire news:', e);
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+const getNewsById = async (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  try {
+    const newsData = (await news.getNewsById(id)) as NewsDataType[];
+
+    if (newsData.length > 0) {
+      res.status(200).json(newsData);
+    } else {
+      res.status(404).json({ message: 'News not found' });
+    }
+  } catch (error) {
+    console.error('Error fetching news:', error);
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+const createNews = async (req: Request, res: Response) => {
+  try {
+    const existingNews = (await news.findNews(
+      req.body.title
+    )) as NewsDataType[];
+    console.log(existingNews);
+
+    if (existingNews.length > 0) {
+      res.status(404).json({ message: 'Already exist news' });
+      return;
+    }
+
+    const response = (await news.saveNews(req.body)) as ResultSetHeader;
+
+    if (response.insertId > 0) {
+      res
+        .status(200)
+        .json({ id: response.insertId, message: 'created successfully' });
+    } else {
+      res.status(404).json({ message: 'Unable to create news' });
+    }
+  } catch (error) {
+    console.log('Save News Error', error);
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+const deleteNews = async (req: Request, res: Response) => {
+  try {
+    // 쿠키로 함께 보내는 newsUserID가 existingNews의 newsUserID값이 같으면 삭제하는 로직을 추가해야함
+    const existingNews = (await news.findNewsById(
+      Number(req.params.id)
+    )) as NewsDataType[];
+
+    if (existingNews.length > 0) {
+      const response = (await news.deleteNews(
+        Number(req.params.id)
+      )) as ResultSetHeader;
+      console.log('delete: ', response);
+      if (response.affectedRows > 0) {
+        res.status(200).json({ message: 'deleted successfully' });
+      } else {
+        res.status(404).json({ message: 'Unable to delete news' });
+      }
+    }
+  } catch (error) {
+    console.log('News Delete Error', error);
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+export { getAllNews, getNewsById, createNews, deleteNews };

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,0 +1,112 @@
+import { Request, Response } from 'express';
+import { QueryResult, ResultSetHeader, RowDataPacket } from 'mysql2/promise'; // 타입 가져오기
+import user from '../models/userModel';
+import { userType } from '../types/user';
+
+const getAllUsers = async (req: Request, res: Response) => {
+  try {
+    if (req.method === 'GET') {
+      // 사용자 데이터 가져오기
+      const rows: QueryResult = await user.getUsers();
+
+      if (rows) {
+        res.status(200).json(rows);
+      } else {
+        res.status(404).json({ message: 'No users found' });
+      }
+    } else {
+      res.setHeader('Allow', ['GET']);
+      res.status(405).json({ message: `Method ${req.method} Not Allowed` });
+    }
+  } catch (error) {
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+const getOneUser = async (req: Request, res: Response) => {
+  try {
+    const User: QueryResult = await user.getUser(Number(req.params.id));
+
+    console.log(`User:`, User);
+
+    if (User) {
+      res.status(200).json(User);
+    } else {
+      res.status(404).json({ message: 'User not found' });
+    }
+  } catch (err) {
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+const createUsers = async (req: Request, res: Response) => {
+  try {
+    if (req.method === 'POST') {
+      const existingUser = await user.findUser(req.body.userID);
+
+      if (existingUser) {
+        res.status(404).json({ message: 'User already exists' });
+      }
+
+      const create = (await user.createUsers(req.body)) as ResultSetHeader;
+
+      if (create.insertId > 0) {
+        res.status(200).json(create.insertId);
+      } else {
+        res.status(404).json({ message: 'User creation error' });
+      }
+    }
+  } catch (err) {
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+const updateUsers = async (req: Request, res: Response) => {
+  try {
+    const userInfo = (await user.getUser(Number(req.params.id))) as userType[];
+
+    if (!userInfo) {
+      res.status(404).json({ message: 'User not found' });
+    }
+
+    const body = {
+      id: userInfo[0].id,
+      ...req.body,
+    };
+
+    const update = (await user.updateUsers(body)) as ResultSetHeader;
+
+    console.log(update);
+
+    if (update.affectedRows > 0) {
+      res.status(200).json({ message: 'Updated successfully' });
+    } else {
+      res.status(404).json({ message: 'Failed to update' });
+    }
+  } catch (err) {
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+const deleteUsers = async (req: Request, res: Response) => {
+  try {
+    const users = (await user.getUser(Number(req.params.id))) as userType[];
+
+    console.log(users);
+    if (users) {
+      res.status(404).json({ message: 'User not found' });
+    }
+
+    const deleteUser = await user.deleteUsers(Number(req.params.id));
+
+    if (deleteUser) {
+      res.status(200).json({ message: 'User deleted successfully' });
+    } else {
+      res.status(404).json({ message: 'User not found' });
+    }
+  } catch (err) {
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};
+
+export { getAllUsers, getOneUser, createUsers, updateUsers, deleteUsers };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,9 +1,23 @@
 import express, { Request, Response, json, urlencoded } from 'express';
 import morgan from 'morgan';
 import cors from 'cors';
+import dotenv from 'dotenv';
+import userRoute from './routers/userRoute';
+import newsRoute from './routers/newsRoute';
+
+// env
+dotenv.config();
 
 const app: express.Application = express();
 const port: number = 4000;
+
+app.use(
+  cors({
+    origin: [process.env.LOCAL_ADDRESS as string],
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    credentials: true,
+  })
+);
 
 app.use(cors());
 
@@ -12,10 +26,13 @@ app.use(urlencoded({ extended: true }));
 
 app.use(morgan('dev'));
 
-app.get('/', (request: Request, response: Response) => {
+app.get('/', (_request: Request, response: Response) => {
   response.send(`App is listening on port ${port}`);
 });
 
 app.listen(port, () => {
   console.log(`App is listening on port ${port}! \n`);
 });
+
+// 라우터 설정
+app.use('/api', userRoute, newsRoute);

--- a/backend/src/models/newsModel.ts
+++ b/backend/src/models/newsModel.ts
@@ -1,0 +1,73 @@
+import { pool } from '../config/db';
+import { NewsDataType } from '../types/news';
+
+const news = {
+  getMyNews: async () => {
+    const [getUsers] = await pool.execute('SELECT * FROM news');
+    return getUsers;
+  },
+
+  getNewsById: async (id: number) => {
+    const [rows] = await pool.execute(
+      'SELECT * FROM news WHERE newsUserID = ?',
+      [id]
+    );
+    return rows;
+  },
+
+  saveNews: async (data: NewsDataType) => {
+    const {
+      author,
+      content,
+      description,
+      publishedAt,
+      title,
+      url,
+      urlToImage,
+      newsUserID,
+    } = data;
+    const { id, name } = data.source;
+
+    const [rows] = await pool.execute(
+      'INSERT INTO news (author, content, description, publishedAt, id, name, title, url, urlToImage, newsUserID) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [
+        author,
+        content,
+        description,
+        publishedAt,
+        id,
+        name,
+        title,
+        url,
+        urlToImage,
+        newsUserID,
+      ]
+    );
+
+    return rows;
+  },
+  findNews: async (title: string) => {
+    const [rows] = await pool.execute('SELECT * FROM news WHERE title = ?', [
+      title,
+    ]);
+
+    return rows;
+  },
+  findNewsById: async (id: number) => {
+    const [rows] = await pool.execute('SELECT * FROM news WHERE newsID = ?', [
+      id,
+    ]);
+    // console.log('newsID로 찾은 뉴스 데이터: ', rows);
+
+    return rows;
+  },
+  deleteNews: async (id: number) => {
+    const [rows] = await pool.execute('DELETE FROM news WHERE newsID LIKE ?', [
+      id,
+    ]);
+
+    return rows;
+  },
+};
+
+export default news;

--- a/backend/src/models/userModel.ts
+++ b/backend/src/models/userModel.ts
@@ -1,0 +1,64 @@
+import { dbConfig } from '../config/db';
+import mysql from 'mysql2/promise';
+import { userType } from '../types/user';
+
+const connection = mysql.createPool(dbConfig);
+
+const user = {
+  getUsers: async () => {
+    const [getUsers] = await connection.execute('SELECT * FROM user');
+
+    return getUsers;
+  },
+  getUser: async (id: Number) => {
+    const [getUser] = await connection.execute(
+      'SELECT * FROM user where id = ?',
+      [id]
+    );
+    return getUser;
+  },
+  findUser: async (userID: string) => {
+    const [findUser] = await connection.execute(
+      'SELECT * FROM user where userID = ?',
+      [userID]
+    );
+    return findUser;
+  },
+  createUsers: async (req: userType) => {
+    const { userID, password, nickname } = req;
+    const [createUser] = await connection.execute(
+      'INSERT INTO user (userID, password, nickname) VALUES (?, ?, ?)',
+      [userID, password, nickname]
+    );
+    return createUser;
+  },
+  updateUsers: async (req: userType) => {
+    const updates: string[] = [];
+    const params: string | number[] = [];
+    const validFields = ['userID', 'password', 'nickname', 'profileImg']; // 허용되는 필드 목록
+
+    for (const field of validFields) {
+      if (req[field] !== undefined) {
+        updates.push(`${field} = ?`);
+        params.push(req[field]);
+      }
+    }
+
+    const sql = `UPDATE user SET ${updates.join(', ')} WHERE id = ?`;
+    params.push(req.id);
+
+    const [updateUser] = await connection.execute(sql, params);
+
+    return updateUser;
+  },
+  deleteUsers: async (id: number) => {
+    const [deleteUser] = await connection.execute(
+      'DELETE FROM user WHERE id LIKE ?',
+      [id]
+    );
+
+    return deleteUser;
+  },
+};
+
+export default user;

--- a/backend/src/routers/newsRoute.ts
+++ b/backend/src/routers/newsRoute.ts
@@ -1,0 +1,16 @@
+import express from 'express';
+import {
+  getAllNews,
+  getNewsById,
+  createNews,
+  deleteNews,
+} from '../controllers/newsController';
+
+const router = express.Router();
+
+router.get('/news', getAllNews);
+router.get('/news/:id', getNewsById);
+router.post('/news', createNews);
+router.delete('/news/:id', deleteNews);
+
+export default router;

--- a/backend/src/routers/userRoute.ts
+++ b/backend/src/routers/userRoute.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import {
+  createUsers,
+  deleteUsers,
+  getAllUsers,
+  getOneUser,
+  updateUsers,
+} from '../controllers/userController';
+
+const router = express.Router();
+
+router.get('/users', getAllUsers);
+router.get('/user/:id', getOneUser);
+router.post('/signup', createUsers);
+router.patch('/user/:id', updateUsers);
+router.delete('/user/:id', deleteUsers);
+
+export default router;

--- a/backend/src/types/news.ts
+++ b/backend/src/types/news.ts
@@ -1,0 +1,17 @@
+interface sourceType {
+  id: null | string;
+  name: null | string;
+}
+
+export interface NewsDataType {
+  id: number;
+  author: string;
+  content: string;
+  description: string;
+  publishedAt: string;
+  source: sourceType;
+  title: string;
+  url: string;
+  urlToImage: string;
+  newsUserID: number;
+}

--- a/backend/src/types/user.ts
+++ b/backend/src/types/user.ts
@@ -1,0 +1,8 @@
+export interface userType {
+  id: number;
+  userID?: string;
+  password?: string;
+  nickname?: string;
+  profileImg?: string;
+  [key: string]: any;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "animejs": "^3.2.2",
     "axios": "^1.7.9",
     "chart.js": "^4.4.7",
+    "cheerio": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide": "^0.473.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       chart.js:
         specifier: ^4.4.7
         version: 4.4.7
+      cheerio:
+        specifier: ^1.0.0
+        version: 1.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -587,6 +590,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -631,6 +637,13 @@ packages:
   chart.js@4.4.7:
     resolution: {integrity: sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==}
     engines: {pnpm: '>=8'}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.0.0:
+    resolution: {integrity: sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==}
+    engines: {node: '>=18.17'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -677,6 +690,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+
+  css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -747,6 +767,19 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -760,9 +793,16 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encoding-sniffer@0.2.0:
+    resolution: {integrity: sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==}
+
   enhanced-resolve@5.18.0:
     resolution: {integrity: sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   es-abstract@1.23.9:
     resolution: {integrity: sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==}
@@ -1060,6 +1100,13 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  htmlparser2@9.1.0:
+    resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1361,6 +1408,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1419,6 +1469,15 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.2.1:
+    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1583,6 +1642,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
@@ -1805,6 +1867,10 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  undici@6.21.1:
+    resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
+    engines: {node: '>=18.17'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -1813,6 +1879,14 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -2326,6 +2400,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -2374,6 +2450,29 @@ snapshots:
   chart.js@4.4.7:
     dependencies:
       '@kurkle/color': 0.3.4
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.0.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.0
+      htmlparser2: 9.1.0
+      parse5: 7.2.1
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 6.21.1
+      whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
     dependencies:
@@ -2428,6 +2527,16 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-select@5.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.1.0: {}
 
   cssesc@3.0.0: {}
 
@@ -2488,6 +2597,24 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.1
@@ -2500,10 +2627,17 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encoding-sniffer@0.2.0:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   enhanced-resolve@5.18.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  entities@4.5.0: {}
 
   es-abstract@1.23.9:
     dependencies:
@@ -2961,6 +3095,17 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  htmlparser2@9.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.0:
@@ -3253,6 +3398,10 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -3324,6 +3473,19 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.2.1
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.2.1
+
+  parse5@7.2.1:
+    dependencies:
+      entities: 4.5.0
 
   path-exists@4.0.0: {}
 
@@ -3485,6 +3647,8 @@ snapshots:
       call-bound: 1.0.3
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.25.0: {}
 
@@ -3795,6 +3959,8 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  undici@6.21.1: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -3802,6 +3968,12 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:

--- a/frontend/src/app/[id]/page.tsx
+++ b/frontend/src/app/[id]/page.tsx
@@ -1,12 +1,24 @@
 'use client';
-import { tabNames } from '@/constants/home';
-import { DataContext } from '@/contexts/home';
-import { ChartBar, Search } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
+
+// constants
+import { tabNames } from '@/constants/home';
+
+// contexts
+import { DataContext } from '@/contexts/home';
+
+// libraries
+import axios from 'axios';
+import { ChartBar, Search } from 'lucide-react';
+import { NewsApiClient } from '../api/newsApi';
 
 export default function NewsDetail() {
+  const [content, setContent] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
   const { selectedData } = useContext(DataContext); // URL에서 id를 추출
 
   // 컴포넌트 변경 boolean
@@ -15,6 +27,32 @@ export default function NewsDetail() {
   function handleInputComponent() {
     setComponentChange(!componentChange);
   }
+
+  const fetchArticleContent = async () => {
+    try {
+      const response = await NewsApiClient.post('/api/news/content', {
+        url: selectedData.url,
+      });
+      console.log('클라이언트측 데이터 페칭 성공: ', response.data.content);
+      const data = response.data.content as string;
+
+      const control = data.split('\\n');
+      console.log(control);
+
+      setContent(control);
+    } catch (e) {
+      console.error('Error fetching article content:', e);
+      throw e; // 에러를 호출하는 곳으로 전달
+    }
+  };
+
+  useEffect(() => {
+    fetchArticleContent();
+  }, []); // articleUrl이 변경될 때마다 실행
+
+  useEffect(() => {
+    console.log('본문 내용: ', content);
+  }, []);
 
   return (
     <div className="min-h-screen flex flex-col items-center">
@@ -93,7 +131,9 @@ export default function NewsDetail() {
           />
         </div>
         <div className="text-[#5C5959] text-sm">
-          {selectedData?.description}
+          {content.map((c) => (
+            <div className="mb-2">{c}.</div>
+          ))}
         </div>
       </main>
 

--- a/frontend/src/app/api/apiClient.ts
+++ b/frontend/src/app/api/apiClient.ts
@@ -1,0 +1,9 @@
+import config from '@/config';
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: config.API_URL,
+  timeout: 5000,
+});
+
+export default apiClient;

--- a/frontend/src/app/api/kakao/route.ts
+++ b/frontend/src/app/api/kakao/route.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const { code } = await req.json(); // POST 요청의 본문 추출
+
+  // 카카오에서 액세스 토큰 요청
+  try {
+    const body = {
+      client_id: process.env.NEXT_PUBLIC_REST_API_KEY,
+      grant_type: 'authorization_code',
+      redirect_uri: process.env.NEXT_PUBLIC_REDIRECT_URI,
+      code,
+    };
+
+    const token = await axios.post(
+      `${process.env.NEXT_PUBLIC_KAKAO_TOKEN_URI}`,
+      body,
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      }
+    );
+
+    console.log(token.data);
+
+    if (token.status !== 200) {
+      return NextResponse.json({ message: 'Token Error' }, { status: 404 });
+    }
+
+    const accessToken = token.data.access_token;
+
+    // 사용자의 정보 요청
+    const userResponse = await axios.get(
+      `${process.env.NEXT_PUBLIC_KAKAO_USER_REQUEST_URI}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
+
+    console.log('사용자 정보 가져오기 성공 ', userResponse.data);
+
+    if (userResponse.data) {
+      return NextResponse.json(userResponse.data, { status: 200 });
+    } else {
+      return NextResponse.json({ message: 'Not Found user' }, { status: 404 });
+    }
+  } catch (error) {
+    console.error('Error getting access token or user info:', error);
+    return NextResponse.json(
+      { message: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/news/content/route.ts
+++ b/frontend/src/app/api/news/content/route.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const { url } = await req.json(); // 요청 본문에서 URL 추출
+
+    console.log('Fetching content from URL:', url);
+
+    // 해당 URL에서 데이터를 가져오기
+    const response = await axios.get(url); // 외부 API나 웹 페이지에서 데이터 가져오기
+    const html = response.data;
+
+    const $ = cheerio.load(html); // cheerio로 HTML 파싱
+    let articleBody = '';
+
+    // 각 p 태그의 텍스트를 가져오고 한글만 필터링
+    $('p').each((i, element) => {
+      const text = $(element).text(); // 각 p 요소의 텍스트 추출
+      // 한글만 남기고 나머지 문자 제거 (온점은 제외)
+      const koreanText = text.replace(/[^가-힣\s]+/g, ''); // 한글과 공백만 남기고 나머지 문자 제거
+
+      articleBody += ' ' + koreanText;
+    });
+
+    // 최종 문자열 양 끝의 공백 제거
+    articleBody = articleBody.trim();
+
+    // '다' 뒤에 \\n을 추가
+    articleBody = articleBody.replace(/다/g, '다\\n');
+
+    // '다' 뒤에 한글이 있는 경우 \\n을 제거하고 이어 붙임
+    articleBody = articleBody.replace(
+      /다\\n(?=[가-힣])|(?<![가-힣])\\n/g,
+      '다'
+    );
+
+    return NextResponse.json({ content: articleBody }, { status: 200 }); // 본문만 반환
+  } catch (err) {
+    console.error('Error fetching article content:', err);
+    return NextResponse.json(
+      { message: 'Internal Server Error!' },
+      { status: 500 }
+    ); // 에러 응답 반환
+  }
+}

--- a/frontend/src/app/api/news/search/route.ts
+++ b/frontend/src/app/api/news/search/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { NewsApiServer } from '@/app/api/newsApi';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const field = searchParams.get('field');
+  console.log(field);
+
+  // field 파라미터 체크
+  if (!field || Array.isArray(field)) {
+    return NextResponse.json(
+      { message: 'Field parameter is required and must be a string' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const newsData = await NewsApiServer.get(
+      `/everything?q=${field}&apiKey=${process.env.NEXT_PUBLIC_NEWS_API_KEY}`
+    );
+
+    if (newsData.data.articles.length > 0) {
+      return NextResponse.json(newsData.data.articles, { status: 200 });
+    } else {
+      return NextResponse.json({ message: 'No news data' }, { status: 404 });
+    }
+  } catch (err) {
+    console.error('Error fetching data:', err);
+    return NextResponse.json(
+      { message: 'Internal Server Error', error: err },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/newsApi.ts
+++ b/frontend/src/app/api/newsApi.ts
@@ -1,0 +1,16 @@
+import config from '@/config';
+import axios from 'axios';
+
+// client에서 요청하는 api
+const NewsApiClient = axios.create({
+  baseURL: config.NEWS_API_URL, // localhost
+  timeout: 5000,
+});
+
+// Server에서 요청하는 api
+const NewsApiServer = axios.create({
+  baseURL: config.NEWS_API_SERVER_URL, //newsapi 주소
+  timeout: 5000,
+});
+
+export { NewsApiClient, NewsApiServer };

--- a/frontend/src/app/economy/page.tsx
+++ b/frontend/src/app/economy/page.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 // constants
-import { domains } from '@/constants/domains';
 import { mediaCompanies, tabNames } from '@/constants/home';
 
 // types
@@ -13,11 +12,11 @@ import { NewsDataType } from '@/types/home';
 
 // libraries
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 import { ChartBar, Search } from 'lucide-react';
 
 // styles
 import '@/app/styles.css';
+import { NewsApiClient } from '../api/newsApi';
 export default function Economy() {
   const pathName = usePathname();
   const [componentChange, setComponentChange] = useState<boolean>(false);
@@ -31,10 +30,8 @@ export default function Economy() {
   >({
     queryKey: ['getScienceData'],
     queryFn: async () => {
-      const response = await axios.get(
-        `https://newsapi.org/v2/everything?q=경제&apiKey=${process.env.NEXT_PUBLIC_NEWSAPI_KEY}&page=1&pageSize=100`
-      );
-      const data = response.data.articles;
+      const response = await NewsApiClient.get(`/api/news/search?field=경제`);
+      const data = response.data;
 
       return data;
     },

--- a/frontend/src/app/kakaoLogin/page.tsx
+++ b/frontend/src/app/kakaoLogin/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+import axios from 'axios';
+import './styles.css';
+import { useEffect } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+export default function KaKaoLoginLoadingPage() {
+  const router = useRouter();
+  const getTokens = useMutation({
+    mutationKey: ['getTokens'],
+    mutationFn: async () => {
+      const kakaoCode = new URL(window.location.href).searchParams.get('code');
+      const response = await axios.post('/api/kakao', {
+        code: kakaoCode,
+      });
+
+      console.log(response);
+
+      return response.data;
+    },
+  });
+  async function getToken() {
+    const kakaoCode = new URL(window.location.href).searchParams.get('code');
+    const response = await axios.post('/api/kakao', {
+      code: kakaoCode,
+    });
+
+    console.log(response);
+  }
+
+  useEffect(() => {
+    // 소셜 로그인 실패 시 에러 핸들링 로직 추가 해야함
+    getTokens.mutateAsync();
+
+    if (getTokens.isSuccess) {
+      setTimeout(() => {
+        router.replace('/');
+      }, 5000);
+    }
+  }, []);
+  return (
+    <div className="container">
+      <div className="macbook">
+        <div className="macbook__topBord">
+          <div className="macbook__display">
+            <div className="macbook__load"></div>
+          </div>
+        </div>
+        <div className="macbook__underBord">
+          <div className="macbook__keybord">
+            <div className="keybord">
+              <div className="keybord__touchbar"></div>
+              <ul className="keybord__keyBox">
+                <li className="keybord__key key--01"></li>
+                <li className="keybord__key key--02"></li>
+                <li className="keybord__key key--03"></li>
+                <li className="keybord__key key--04"></li>
+                <li className="keybord__key key--05"></li>
+                <li className="keybord__key key--06"></li>
+                <li className="keybord__key key--07"></li>
+                <li className="keybord__key key--08"></li>
+                <li className="keybord__key key--09"></li>
+                <li className="keybord__key key--10"></li>
+                <li className="keybord__key key--11"></li>
+                <li className="keybord__key key--12"></li>
+                <li className="keybord__key key--13"></li>
+              </ul>
+              <ul className="keybord__keyBox--under">
+                <li className="keybord__key key--14"></li>
+                <li className="keybord__key key--15"></li>
+                <li className="keybord__key key--16"></li>
+                <li className="keybord__key key--17"></li>
+                <li className="keybord__key key--18"></li>
+                <li className="keybord__key key--19"></li>
+                <li className="keybord__key key--20"></li>
+                <li className="keybord__key key--21"></li>
+                <li className="keybord__key key--22"></li>
+                <li className="keybord__key key--23"></li>
+                <li className="keybord__key key--24"></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/kakaoLogin/styles.css
+++ b/frontend/src/app/kakaoLogin/styles.css
@@ -1,0 +1,428 @@
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+.macbook {
+  position: relative;
+  width: 228px;
+  height: 260px;
+}
+.macbook__topBord {
+  position: absolute;
+  z-index: 0;
+  top: 34px;
+  left: 0;
+  width: 128px;
+  height: 116px;
+  border-radius: 6px;
+  transform-origin: center;
+  background: linear-gradient(-135deg, #c8c9c9 52%, #8c8c8c 56%);
+  transform: scale(0) skewY(-30deg);
+  animation: topbord 0.4s 1.7s ease-out;
+  animation-fill-mode: forwards;
+}
+.macbook__topBord::before {
+  content: '';
+  position: absolute;
+  z-index: 2;
+  top: 8px;
+  left: 6px;
+  width: 100%;
+  height: 100%;
+  border-radius: 6px;
+  background: #000;
+}
+.macbook__topBord::after {
+  content: '';
+  position: absolute;
+  z-index: 1;
+  bottom: -7px;
+  left: 8px;
+  width: 168px;
+  height: 12px;
+  transform-origin: left bottom;
+  transform: rotate(-42deg) skew(-4deg);
+  background: linear-gradient(-135deg, #c8c9c9 52%, #8c8c8c 56%);
+}
+.macbook__display {
+  position: absolute;
+  z-index: 10;
+  top: 17px;
+  left: 12px;
+  z-index: 2;
+  width: calc(100% - 12px);
+  height: calc(100% - 18px);
+  background: linear-gradient(45deg, #3ba9ff, #c82aff);
+}
+.macbook__display::before {
+  content: '';
+  position: absolute;
+  z-index: 5;
+  top: -9px;
+  left: -6px;
+  width: calc(100% + 12px);
+  height: calc(100% + 18px);
+  border-radius: 6px;
+  background: linear-gradient(
+    60deg,
+    rgba(255, 255, 255, 0) 60%,
+    rgba(255, 255, 255, 0.3) 60%
+  );
+}
+.macbook__load {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #222;
+  animation: display 0.4s 4.3s ease;
+  opacity: 1;
+  animation-fill-mode: forwards;
+}
+.macbook__load:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
+  width: 80px;
+  height: 6px;
+  border-radius: 3px;
+  box-sizing: border-box;
+  border: solid 1px #fff;
+}
+.macbook__load:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 18px;
+  bottom: 0;
+  margin: auto;
+  width: 0;
+  height: 6px;
+  border-radius: 3px;
+  background: #fff;
+  animation: load 2s 2s ease-out;
+  animation-fill-mode: forwards;
+}
+.macbook__underBord {
+  position: relative;
+  left: 42px;
+  bottom: -145px;
+  width: 150px;
+  height: 90px;
+  border-radius: 6px;
+  transform-origin: center;
+  transform: rotate(-30deg) skew(30deg);
+  background: linear-gradient(-45deg, #c8c9c9 61%, #8c8c8c 66%);
+  animation: modal 0.5s 1s ease-out;
+  opacity: 0;
+  animation-fill-mode: forwards;
+}
+.macbook__underBord::before {
+  content: '';
+  position: absolute;
+  z-index: 3;
+  top: -8px;
+  left: 8px;
+  width: 100%;
+  height: 100%;
+  border-radius: 6px;
+  background: #dcdede;
+}
+.macbook__underBord::after {
+  content: '';
+  position: absolute;
+  z-index: 2;
+  top: -8px;
+  left: 12px;
+  width: 170px;
+  height: 15px;
+  transform-origin: top left;
+  background: linear-gradient(-45deg, #c8c9c9 61%, #8c8c8c 66%);
+  transform: rotate(31deg) skew(-16deg);
+}
+.macbook__keybord {
+  position: relative;
+  top: 0;
+  left: 16px;
+  z-index: 3;
+  border-radius: 3px;
+  width: calc(100% - 16px);
+  height: 45px;
+  background: #c8c9c9;
+}
+.macbook__keybord::before {
+  content: '';
+  position: absolute;
+  bottom: -30px;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  width: 40px;
+  height: 25px;
+  border-radius: 3px;
+  background: #c8c9c9;
+}
+.keybord {
+  position: relative;
+  top: 2px;
+  left: 2px;
+  display: flex;
+  flex-direction: column;
+  width: calc(100% - 3px);
+  height: calc(100% - 4px);
+}
+.keybord__touchbar {
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: #000;
+}
+.keybord__keyBox {
+  display: grid;
+  grid-template-rows: 3fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+  width: 100%;
+  height: 24px;
+  margin: 1px 0 0 0;
+  padding: 0 0 0 1px;
+  box-sizing: border-box;
+  list-style: none;
+}
+.keybord__key {
+  position: relative;
+  width: 8px;
+  height: 7px;
+  margin: 1px;
+  background: #000;
+}
+.keybord__keyBox .keybord__key {
+  transform: translate(60px, -60px);
+  animation: key 0.2s 1.4s ease-out;
+  animation-fill-mode: forwards;
+  opacity: 0;
+}
+.keybord__keyBox .keybord__key::before,
+.keybord__keyBox .keybord__key::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+}
+.keybord__key::before {
+  top: 8px;
+  transform: translate(20px, -20px);
+  animation: key1 0.2s 1.5s ease-out;
+  animation-fill-mode: forwards;
+}
+.keybord__key::after {
+  top: 16px;
+  transform: translate(40px, -40px);
+  animation: key2 0.2s 1.6s ease-out;
+  animation-fill-mode: forwards;
+}
+.keybord__keyBox .key--12::before {
+  width: 10px;
+}
+.keybord__keyBox .key--13::before {
+  height: 10px;
+}
+.key--01 {
+  grid-row: 1 / 2;
+  grid-column: 1 / 2;
+}
+.key--02 {
+  grid-row: 1 / 2;
+  grid-column: 2 / 3;
+}
+.key--03 {
+  grid-row: 1 / 2;
+  grid-column: 3 / 4;
+}
+.key--04 {
+  grid-row: 1 / 2;
+  grid-column: 4 / 5;
+}
+.key--05 {
+  grid-row: 1 / 2;
+  grid-column: 5 / 6;
+}
+.key--06 {
+  grid-row: 1 / 2;
+  grid-column: 6 / 7;
+}
+.key--07 {
+  grid-row: 1 / 2;
+  grid-column: 7 / 8;
+}
+.key--08 {
+  grid-row: 1 / 2;
+  grid-column: 8 / 9;
+}
+.key--09 {
+  grid-row: 1 / 2;
+  grid-column: 9 / 10;
+}
+.key--10 {
+  grid-row: 1 / 2;
+  grid-column: 10 / 11;
+}
+.key--11 {
+  grid-row: 1 / 2;
+  grid-column: 11 / 12;
+}
+.key--12 {
+  grid-row: 1 / 2;
+  grid-column: 12 / 13;
+}
+.key--13 {
+  grid-row: 1 / 2;
+  grid-column: 13 / 14;
+}
+.keybord__keyBox--under {
+  margin: 0;
+  padding: 0 0 0 1px;
+  box-sizing: border-box;
+  list-style: none;
+  display: flex;
+}
+.keybord__keyBox--under .keybord__key {
+  transform: translate(80px, -80px);
+  animation: key3 0.3s 1.6s linear;
+  animation-fill-mode: forwards;
+  opacity: 0;
+}
+.key--19 {
+  width: 28px;
+}
+@keyframes topbord {
+  0% {
+    transform: scale(0) skewY(-30deg);
+  }
+  30% {
+    transform: scale(1.1) skewY(-30deg);
+  }
+  45% {
+    transform: scale(0.9) skewY(-30deg);
+  }
+  60% {
+    transform: scale(1.05) skewY(-30deg);
+  }
+  75% {
+    transform: scale(0.95) skewY(-30deg);
+  }
+  90% {
+    transform: scale(1.02) skewY(-30deg);
+  }
+  100% {
+    transform: scale(1) skewY(-30deg);
+  }
+}
+@keyframes display {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes load {
+  0% {
+    width: 0;
+  }
+  20% {
+    width: 40px;
+  }
+  30% {
+    width: 40px;
+  }
+  60% {
+    width: 60px;
+  }
+  90% {
+    width: 60px;
+  }
+  100% {
+    width: 80px;
+  }
+}
+
+@keyframes modal {
+  0% {
+    transform: scale(0) rotate(-30deg) skew(30deg);
+    opacity: 0;
+  }
+  30% {
+    transform: scale(1.1) rotate(-30deg) skew(30deg);
+    opacity: 1;
+  }
+  45% {
+    transform: scale(0.9) rotate(-30deg) skew(30deg);
+    opacity: 1;
+  }
+  60% {
+    transform: scale(1.05) rotate(-30deg) skew(30deg);
+    opacity: 1;
+  }
+  75% {
+    transform: scale(0.95) rotate(-30deg) skew(30deg);
+    opacity: 1;
+  }
+  90% {
+    transform: scale(1.02) rotate(-30deg) skew(30deg);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1) rotate(-30deg) skew(30deg);
+    opacity: 1;
+  }
+}
+
+@keyframes key {
+  0% {
+    transform: translate(60px, -60px);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(0px, 0px);
+    opacity: 1;
+  }
+}
+@keyframes key1 {
+  0% {
+    transform: translate(20px, -20px);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(0px, 0px);
+    opacity: 1;
+  }
+}
+@keyframes key2 {
+  0% {
+    transform: translate(40px, -40px);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(0px, 0px);
+    opacity: 1;
+  }
+}
+@keyframes key3 {
+  0% {
+    transform: translate(80px, -80px);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(0px, 0px);
+    opacity: 1;
+  }
+}

--- a/frontend/src/app/life/page.tsx
+++ b/frontend/src/app/life/page.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 // constants
-import { domains } from '@/constants/domains';
 import { mediaCompanies, tabNames } from '@/constants/home';
 
 // types
@@ -13,11 +12,14 @@ import { NewsDataType } from '@/types/home';
 
 // libraries
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 import { ChartBar, Search } from 'lucide-react';
 
 // styles
 import '@/app/styles.css';
+
+// apis
+import { NewsApiClient } from '../api/newsApi';
+
 export default function Life() {
   const pathName = usePathname();
   const [componentChange, setComponentChange] = useState<boolean>(false);
@@ -26,23 +28,19 @@ export default function Life() {
     setComponentChange(!componentChange);
   }
 
-  const {
-    data: LifeData,
-    refetch: refetchLifeData,
-    isLoading: isLifeDataLoading,
-  } = useQuery<NewsDataType[]>({
-    queryKey: ['getScienceData'],
-    queryFn: async () => {
-      const response = await axios.get(
-        `https://newsapi.org/v2/everything?q=생활&apiKey=${process.env.NEXT_PUBLIC_NEWSAPI_KEY}&page=1&pageSize=100`
-      );
-      const data = response.data.articles;
+  const { data: LifeData, refetch: refetchLifeData } = useQuery<NewsDataType[]>(
+    {
+      queryKey: ['getScienceData'],
+      queryFn: async () => {
+        const response = await NewsApiClient.get(`/api/news/search?field=생활`);
+        const data = response.data;
 
-      console.log(data);
+        console.log(data);
 
-      return data;
-    },
-  });
+        return data;
+      },
+    }
+  );
 
   useEffect(() => {
     refetchLifeData();

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -21,6 +21,11 @@ export default function Login() {
     router.push('/');
   }
 
+  function kakaoLogin() {
+    const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_REST_API_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_REDIRECT_URI}&response_type=code`;
+    window.location.href = kakaoURL;
+  }
+
   return (
     <div className="relative bottom-10 flex flex-row w-full h-[420px] items-center justify-around">
       <div className="imgElement relative">
@@ -31,7 +36,7 @@ export default function Login() {
           width={400}
           height={400}
         />
-        {loginImgElement.map(
+        {/* {loginImgElement.map(
           ({ img, left, top, bottom, alt, animationClass }, index) => {
             return (
               <Image
@@ -49,7 +54,7 @@ export default function Login() {
               />
             );
           }
-        )}
+        )} */}
       </div>
       <div className="containerAnimations relative top-10 flex flex-col justify-around w-[500px] h-[500px] items-center bg-white rounded-[0.5rem]">
         <div className="loginElement flex flex-row w-2/4 items-center">
@@ -87,6 +92,7 @@ export default function Login() {
           <Button
             className="flex flex-row justify-center items-center w-[400px] h-[40px] bg-[#FEE608] hover:bg-[#FEE608] rounded-[6px]"
             variant="outline"
+            onClick={() => kakaoLogin()}
           >
             <Image
               src={'/images/kakao_login_symbol.png'}
@@ -94,8 +100,8 @@ export default function Login() {
               width={25}
               height={25}
             />
-            <span className="ml-2 text-[1rem] text-base font-sans font-[600]">
-              카카오 로그인
+            <span className="ml-2 text-[1rem] text-base font-sans font-[600] text-[#282828]">
+              카카오 계정으로 로그인
             </span>
           </Button>
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -34,14 +34,14 @@ export default function Home() {
           delay: () => anime.random(0, 1000),
           direction: 'reverse',
           complete: () => {
-            setSubjectVisible(true); // 세상 사는 눈을 키운다 보이기
+            setSubjectVisible(true);
             setTimeout(() => {
-              setTitleVisible(true); // News-eye 나중에 보이기
+              setTitleVisible(true);
             }, 500);
           },
         });
       });
-    }, 0); // 0ms 지연을 주어 렌더링 후 함수를 실행
+    }, 0);
 
     return () => clearTimeout(timer);
   }, []);

--- a/frontend/src/app/politics/page.tsx
+++ b/frontend/src/app/politics/page.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 // constants
-import { domains } from '@/constants/domains';
 import { mediaCompanies, tabNames } from '@/constants/home';
 
 // types
@@ -13,11 +12,13 @@ import { NewsDataType } from '@/types/home';
 
 // libraries
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 import { ChartBar, Search } from 'lucide-react';
 
 // styles
 import '@/app/styles.css';
+
+// apis
+import { NewsApiClient } from '../api/newsApi';
 
 export default function Politics() {
   const pathName = usePathname();
@@ -34,10 +35,8 @@ export default function Politics() {
   } = useQuery<NewsDataType[]>({
     queryKey: ['getScienceData'],
     queryFn: async () => {
-      const response = await axios.get(
-        `https://newsapi.org/v2/everything?q=정치&apiKey=${process.env.NEXT_PUBLIC_NEWSAPI_KEY}&page=1&pageSize=100`
-      );
-      const data = response.data.articles;
+      const response = await NewsApiClient.get(`/api/news/search?field=정치`);
+      const data = response.data;
 
       console.log(data);
 

--- a/frontend/src/app/science/page.tsx
+++ b/frontend/src/app/science/page.tsx
@@ -21,6 +21,9 @@ import { ContextType, NewsDataType } from '@/types/home';
 // contexts
 import { DataContext } from '@/contexts/home';
 
+// apis
+import { NewsApiClient } from '../api/newsApi';
+
 export default function Science() {
   const context = useContext<ContextType>(DataContext);
 
@@ -41,12 +44,10 @@ export default function Science() {
   >({
     queryKey: ['getScienceData'],
     queryFn: async () => {
-      const response = await axios.get(
-        `https://newsapi.org/v2/everything?q=과학&apiKey=${process.env.NEXT_PUBLIC_NEWSAPI_KEY}&page=1&pageSize=100`
-      );
-      const data = response.data.articles;
+      const response = await NewsApiClient.get(`/api/news/search?field=과학`);
+      const data = response.data;
 
-      console.log(data);
+      // console.log(data);
 
       return data;
     },

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -15,18 +15,11 @@ import { signupImgElement } from '@/constants/signup';
 export default function Signup() {
   return (
     <div className="relative bottom-10 flex flex-row w-full h-[420px] items-center justify-around">
-      <div className="containerAnimation relative top-10 flex flex-col justify-around w-[500px] h-[500px] items-center bg-[#ffffff] rounded-[0.5rem]">
-        <div className="loginElement flex flex-row w-2/4 items-center ">
-          <Image
-            src={'/images/news-eye.png'}
-            width={70}
-            height={70}
-            alt="로고"
-          />
-          <div className="loginElement font-black text-3xl font-[Open_Sans]">
-            Sign Up
-          </div>
+      <div className="containerAnimation relative top-10 flex flex-col justify-around w-[500px] h-[500px] items-center bg-[#ffffff] rounded-[0.5rem] gap-4">
+        <div className="loginElement font-black text-2xl font-[Open_Sans] mt-4">
+          회원가입
         </div>
+
         <div className="loginElement flex flex-col w-full gap-5  items-center">
           <Input
             type="text"
@@ -72,7 +65,7 @@ export default function Signup() {
           width={400}
           height={400}
         />
-        {signupImgElement.map(
+        {/* {signupImgElement.map(
           ({ img, left, top, bottom, alt, animationClass }, index) => {
             return (
               <Image
@@ -90,7 +83,7 @@ export default function Signup() {
               />
             );
           }
-        )}
+        )} */}
       </div>
     </div>
   );

--- a/frontend/src/app/society/page.tsx
+++ b/frontend/src/app/society/page.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 // constants
-import { domains } from '@/constants/domains';
 import { mediaCompanies, tabNames } from '@/constants/home';
 
 // types
@@ -13,11 +12,13 @@ import { NewsDataType } from '@/types/home';
 
 // libraries
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
 import { ChartBar, Search } from 'lucide-react';
 
 // styles
 import '@/app/styles.css';
+
+// apis
+import { NewsApiClient } from '../api/newsApi';
 
 export default function Society() {
   const pathName = usePathname();
@@ -27,17 +28,13 @@ export default function Society() {
     setComponentChange(!componentChange);
   }
 
-  const {
-    data: SocietyData,
-    refetch: refetchSocietyData,
-    isLoading: isSocietyDataLoading,
-  } = useQuery<NewsDataType[]>({
+  const { data: SocietyData, refetch: refetchSocietyData } = useQuery<
+    NewsDataType[]
+  >({
     queryKey: ['getScienceData'],
     queryFn: async () => {
-      const response = await axios.get(
-        `https://newsapi.org/v2/everything?q=사회&apiKey=${process.env.NEXT_PUBLIC_NEWSAPI_KEY}&page=1&pageSize=100`
-      );
-      const data = response.data.articles;
+      const response = await NewsApiClient.get(`/api/news/search?field=사회`);
+      const data = response.data;
 
       console.log(data);
 

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -1,0 +1,6 @@
+const config = {
+  API_URL: process.env.NEXT_PUBLIC_API_ADDRESS,
+  NEWS_API_URL: process.env.NEXT_PUBLIC_NEWS_API_ADDRESS,
+  NEWS_API_SERVER_URL: process.env.NEXT_PUBLIC_NEWS_SERVER_API_ADDRESS,
+};
+export default config;


### PR DESCRIPTION
<!-- 제목: [Feature] PR내용
ex) [Feature] 프로젝트 초기 세팅 -->

## 이슈 번호
#7 
## 구현 내용
- 유저 CRUD, 소셜 로그인 구현
- 유저가 저장할 뉴스 데이터 api 구현 - 전체 데이터, 개별 뉴스 데이터 ⇒ GET  
- 본문 내용 가져오기 ⇒ next api handler 통해 구현

## 관련 기술 설명

### 소셜 로그인 
- 소셜 로그인 구현하기 ⇒ 클라이언트에서 인가 코드 넘겨주면 Next api handler로  토큰 발급 후 유저 정보까지 받아와서 클라이언트로 넘겨주는 방식으로 구현함
    - 클라이언트에 직접 액세스 토큰을 노출하지 않을 수 있고 인가 코드만을 사용하여 직접적인 민감 정보 노출을 방지

### 본문 내용 가져오기
[참고한 블로그 주소](https://junuuu.tistory.com/311)
Axios를 통해 해당 URL에서 데이터를 가져오는 방식으로 해결했다
해당 작업은 클라이언트에서 실행하게 되면 CORS 에러가 발생하기 떄문에 Next API Handler를 통해 url를 HTTP 요청을 통해 코드를 가져오는 동작을 실행
```tsx
import axios from 'axios';
import * as cheerio from 'cheerio';
import { NextResponse } from 'next/server';

export async function POST(req: Request) {
  try {
    const { url } = await req.json(); // 요청 본문에서 URL 추

    // 해당 URL에서 데이터를 가져오기
    const response = await axios.get(url); // 외부 API나 웹 페이지에서 데이터 가져오기
    const html = response.data;

    const $ = cheerio.load(html); // cheerio로 HTML 파싱
    let articleBody = '';

    // 각 p 태그의 텍스트를 가져오고 한글만 필터링
    $('p').each((i, element) => {
      const text = $(element).text(); // 각 p 요소의 텍스트 추출
      // 한글만 남기고 나머지 문자 제거 (온점은 제외)
      const koreanText = text.replace(/[^가-힣\s]+/g, ''); // 한글과 공백만 남기고 나머지 문자 제거

      articleBody += ' ' + koreanText;
    });

    // 최종 문자열 양 끝의 공백 제거
    articleBody = articleBody.trim();

    // '다' 뒤에 \\n을 추가
    articleBody = articleBody.replace(/다/g, '다\\n');

    // '다' 뒤에 한글이 있는 경우 \\n을 제거하고 이어 붙임
    articleBody = articleBody.replace(
      /다\\n(?=[가-힣])|(?<![가-힣])\\n/g,
      '다'
    );

    return NextResponse.json({ content: articleBody }, { status: 200 });
  } catch (err) {
    console.error('Error fetching article content:', err);
    return NextResponse.json(
      { message: 'Internal Server Error!' },
      { status: 500 }
    );
  }
}

```
HTML의 원시 코드를 가져오기 때문에 뉴스의 본문만을 원하는 제 의도에는 맞지 않음
Node.js에서 사용하는 Cheerio를 통해 HTML을 파싱하여 본문을 추출하는 로직을 수행하기로 결정

p 태그 안에 데이터가 포함되어 있으며, 한글 이외의 다른 언어로 작성된 기사 내용도 함께 수집하는 것은 불필요한 행동이다. 따라서 한글만 가져오는 정규 표현식을 추가하여 다른 나라 언어와 기호를 제외한다.

```tsx
$('p').each((i, element) => {
  const text = $(element).text(); // 각 p 요소의 텍스트 추출
  // 한글만 남기고 나머지 문자 제거 (온점은 제외)
  const koreanText = text.replace(/[^가-힣\s]+/g, ''); // 한글과 공백만 남기고 나머지 문자 제거
});
```
'다'로 어미가 종료되는 부분에 줄바꿈('\n')을 삽입하여 문장을 구분할 수 있도록 했다. '다면', '다만', '다O'와 같이 뒤에 '다'로 어미가 종결되지 않는 경우에는 줄바꿈을 제거하고 이어 붙이는 로직으로 처리했다. 

```tsx
// '다' 뒤에 한글이 있는 경우 \\n을 제거하고 이어 붙임
articleBody = articleBody.replace(
  /다\\n(?=[가-힣])|(?<![가-힣])\\n/g,
  '다'
);
```


